### PR TITLE
Fix multiplier conditional spacing

### DIFF
--- a/core/RT_Margin_clipboard.py
+++ b/core/RT_Margin_clipboard.py
@@ -64,7 +64,7 @@ def get_multiplier(value):
         return 1.60
     elif 16_000_000.00 <= value < 32_000_000.00:
         return 1.55
-    elif value >=32_000_000.00:
+    elif value >= 32_000_000.00:
         return 1.50
     else:
         return 1.75  # Default multiplier for values less than 1.00


### PR DESCRIPTION
## Summary
- fix spacing error in `get_multiplier` conditional

## Testing
- `python -m py_compile core/RT_Margin_clipboard.py`

------
https://chatgpt.com/codex/tasks/task_e_684fc5d4e458832cb0176e2166110f81